### PR TITLE
Update jsDelivr link

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Include `aping-plugin-tumblr.min.js` in your apiNG application
 <script src="node_modules/aping-plugin-tumblr/dist/aping-plugin-tumblr.min.js"></script>
 
 <!-- when using cdn file -->
-<script src="//cdn.jsdelivr.net/aping.plugin-tumblr/latest/aping-plugin-tumblr.min.js"></script>
+<script src="//cdn.jsdelivr.net/npm/aping-plugin-tumblr@latest/dist/aping-plugin-tumblr.min.js"></script>
 
 <!-- when using downloaded files -->
 <script src="aping-plugin-tumblr.min.js"></script>


### PR DESCRIPTION
[jsDelivr switched to a fully automated system](https://www.jsdelivr.com/features), that can serve files from npm and GitHub. This means all future releases will be available automatically, but will use a new link structure.

I updated the link now so you don't forget to do it when you release a new version.

You can find links for all files at https://www.jsdelivr.com/package/npm/aping-plugin-tumblr.

Feel free to ping me if you have any questions regarding this change.